### PR TITLE
Removing achievement and loot announcement replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project uses [Semantic Versioning](http://semver.org/).
 ## [1.11.0] -- Unreleased
 ### Removed
 - Removed replication of achievements and loot announcements between co-guilds.
+  The `SendChatMessage` function was made partially protected in 8.2.5, and
+  events that are not triggered by hardware events cannot use the function.
 
 ### Changed
 - Updated the TOC for WoW 8.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 This project uses [Semantic Versioning](http://semver.org/).
 
 ## [1.11.0] -- Unreleased
-### Fixed
-- Updated debug message call stack parsing for 8.3.
+### Removed
+- Removed replication of achievements and loot announcements between co-guilds.
 
 ### Changed
 - Updated the TOC for WoW 8.3.0.
 - Refactored CHAT_MSG_SYSTEM handling to use an abstract factory and added
   full unit testing for the polymorphic classes. 
+
+### Fixed
+- Updated debug message call stack parsing for 8.3.
 
 ## [1.10.1] -- 2019-09-24
 ### Updated

--- a/Channel.lua
+++ b/Channel.lua
@@ -262,7 +262,6 @@ Transmit Methods
 -- @param type The message type.
 --   Accepted values are:
 --     GW_MTYPE_CHAT
---     GW_MTYPE_ACHIEVEMENT
 --     GW_MTYPE_BROADCAST
 --     GW_MTYPE_NOTICE
 --     GW_MTYPE_REQUEST
@@ -298,10 +297,6 @@ function GwChannel:tl_send(type, message)
     local opcode
     if type == GW_MTYPE_CHAT then
         opcode = 'C'
-    elseif type == GW_MTYPE_ACHIEVEMENT then
-        opcode = 'A'
-    elseif type == GW_MTYPE_LOOT then
-        opcode = 'L'
     elseif type == GW_MTYPE_BROADCAST then
         opcode = 'B'
     elseif type == GW_MTYPE_NOTICE then
@@ -471,10 +466,6 @@ function GwChannel:tl_receive(...)
     local type = GW_MTYPE_NONE
     if opcode == 'C' then
         type = GW_MTYPE_CHAT
-    elseif opcode == 'A' then
-        type = GW_MTYPE_ACHIEVEMENT
-    elseif opcode == 'L' then
-        type = GW_MTYPE_LOOT
     elseif opcode == 'B' then
         type = GW_MTYPE_BROADCAST
     elseif opcode == 'N' then
@@ -486,7 +477,7 @@ function GwChannel:tl_receive(...)
     elseif opcode == 'E' then
         type = GW_MTYPE_EXTERNAL
     else
-        gw.Debug(GW_LOG_ERROR, 'unknown segment opcode: %s', opcode)
+        gw.Debug(GW_LOG_WARNING, 'unknown segment opcode: %s', opcode)
     end
     return sender, guild_id, type, message
 end

--- a/Chat.lua
+++ b/Chat.lua
@@ -37,14 +37,6 @@ function gw.handlerGuildChat(type, guild_id, content, arglist)
     local sender = arglist[2]
     if type == GW_MTYPE_CHAT then
         gw.ReplicateMessage('GUILD', content[1], guild_id, arglist)
-    elseif type == GW_MTYPE_ACHIEVEMENT then
-        if gw.settings:get('achievements') then
-            gw.ReplicateMessage('GUILD_ACHIEVEMENT', content[1], guild_id, arglist)
-        end
-    elseif type == GW_MTYPE_LOOT then
-        if gw.settings:get('achievements') then
-            gw.ReplicateMessage('LOOT', content[1], guild_id, arglist)
-        end
     elseif type == GW_MTYPE_BROADCAST then
         local action, target, rank = unpack(content)
         if action == 'join' then
@@ -95,8 +87,6 @@ end
 -- Accepted values:
 -- 'GUILD'
 -- 'OFFICER'
--- 'GUILD_ACHIEVEMENT'
--- 'LOOT'
 -- 'SYSTEM'
 -- @param message The message to replicate.
 -- @param guild_id (optional) Guild ID of the sender.

--- a/Constants.lua
+++ b/Constants.lua
@@ -64,15 +64,13 @@ GW_CTYPE_ADDON      = 2
 --
 GW_MTYPE_NONE           = 0
 GW_MTYPE_CHAT           = 1
-GW_MTYPE_ACHIEVEMENT    = 2
-GW_MTYPE_LOOT           = 3
-GW_MTYPE_BROADCAST      = 4
-GW_MTYPE_CONTROL        = 5
-GW_MTYPE_REQUEST        = 6
-GW_MTYPE_RESPONSE       = 7
-GW_MTYPE_NOTICE         = 8
-GW_MTYPE_ADDON          = 9
-GW_MTYPE_EXTERNAL       = 10
+GW_MTYPE_BROADCAST      = 2
+GW_MTYPE_CONTROL        = 3
+GW_MTYPE_REQUEST        = 4
+GW_MTYPE_RESPONSE       = 5
+GW_MTYPE_NOTICE         = 6
+GW_MTYPE_ADDON          = 7
+GW_MTYPE_EXTERNAL       = 8
 
 
 --

--- a/GUILD_QUICKSTART.md
+++ b/GUILD_QUICKSTART.md
@@ -20,7 +20,7 @@ Definitions
 -----------
 
 Bridging
-> Replication of chat events within one guild into the guild, achievement, and officer chat of another guild.
+> Replication of chat events within one guild into the guild and officer chat channels of another guild.
 
 Confederation
 > A large WoW guild that is partitioned into smaller guilds to comply with Blizzard's guild size limit.

--- a/Globals.lua
+++ b/Globals.lua
@@ -70,8 +70,6 @@ gw.usage = [[
         -- Reload the configuration.
   reset
         -- Reset communications and reload the configuration.
-  achievements <on|off>
-        -- Toggle display of confederation achievements.
   roster <on|off>
         -- Toggle display of confederation online, offline, join, and leave messages.
   rank <on|off>

--- a/GreenWall.lua
+++ b/GreenWall.lua
@@ -176,9 +176,7 @@ function GreenWall_OnLoad(self)
     self:RegisterEvent('CHAT_MSG_CHANNEL_LEAVE')
     self:RegisterEvent('CHAT_MSG_CHANNEL_NOTICE')
     self:RegisterEvent('CHAT_MSG_GUILD')
-    self:RegisterEvent('CHAT_MSG_LOOT')
     self:RegisterEvent('CHAT_MSG_OFFICER')
-    self:RegisterEvent('CHAT_MSG_GUILD_ACHIEVEMENT')
     self:RegisterEvent('CHAT_MSG_SYSTEM')
     self:RegisterEvent('GUILD_ROSTER_UPDATE')
     self:RegisterEvent('PLAYER_ENTERING_WORLD')
@@ -297,18 +295,6 @@ function GreenWall_OnEvent(self, event, ...)
         local message, sender, language, _, _, flags, _, chanNum = select(1, ...)
         gw.Debug(GW_LOG_DEBUG, 'event=%s, sender=%s, message=%q', event, sender, message)
 
-    elseif event == 'CHAT_MSG_LOOT' then
-
-        local message, sender, _, _, _, flags, _, chanNum = select(1, ...)
-        gw.Debug(GW_LOG_DEBUG, 'event=%s, sender=%s, message=%q', event, sender, message)
-        item = gw.GetItemString(message)
-        if item and gw.IsLegendary(item) then
-            if gw.iCmp(gw.GlobalName(sender), gw.player) then
-                newmsg = message:gsub('You receive', gw.player .. ' receives') -- Convert to third-person
-                gw.config.channel.guild:send(GW_MTYPE_LOOT, newmsg)
-            end
-        end
-
     elseif event == 'CHAT_MSG_OFFICER' then
 
         -- Messages will be forwarded by the ChatEdit_ParseText hook
@@ -320,14 +306,6 @@ function GreenWall_OnEvent(self, event, ...)
         local prefix, payload, dist, sender = select(1, ...)
         if prefix == 'GreenWall' and dist == 'GUILD' then
             gw.ReceiveLocal(gw.GlobalName(sender), payload)
-        end
-
-    elseif event == 'CHAT_MSG_GUILD_ACHIEVEMENT' then
-
-        local message, sender, _, _, _, flags, _, chanNum = select(1, ...)
-        gw.Debug(GW_LOG_DEBUG, 'event=%s, sender=%s, message=%q', event, sender, message)
-        if gw.iCmp(gw.GlobalName(sender), gw.player) then
-            gw.config.channel.guild:send(GW_MTYPE_ACHIEVEMENT, message)
         end
 
     elseif event == 'CHAT_MSG_CHANNEL_JOIN' then

--- a/GreenWall.xml
+++ b/GreenWall.xml
@@ -98,22 +98,9 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
                     <OnLoad>getglobal(self:GetName() .. "Text"):SetText("Show co-guild tags");</OnLoad>
                 </Scripts>
             </CheckButton>
-            <CheckButton name="$parentOptionAchievements" inherits="InterfaceOptionsCheckButtonTemplate">
-                <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentOptionTag"
-                            relativePoint="BOTTOMLEFT">
-                        <Offset>
-                            <AbsDimension x="0" y="-8"/>
-                        </Offset>
-                    </Anchor>
-                </Anchors>
-                <Scripts>
-                    <OnLoad>getglobal(self:GetName() .. "Text"):SetText("Show co-guild achievement announcements");</OnLoad>
-                </Scripts>
-            </CheckButton>
             <CheckButton name="$parentOptionRoster" inherits="InterfaceOptionsCheckButtonTemplate">
                 <Anchors>
-                    <Anchor point="TOPLEFT" relativeTo="$parentOptionAchievements"
+                    <Anchor point="TOPLEFT" relativeTo="$parentOptionTag"
                             relativePoint="BOTTOMLEFT">
                         <Offset>
                             <AbsDimension x="0" y="-8"/>

--- a/Interface.lua
+++ b/Interface.lua
@@ -40,7 +40,6 @@ function GreenWallInterfaceFrame_LoadOptions(self, mode)
     end
     getglobal(self:GetName() .. "OptionMode"):SetChecked(mode == GW_MODE_ACCOUNT)
     getglobal(self:GetName() .. "OptionTag"):SetChecked(gw.settings:get('tag', mode))
-    getglobal(self:GetName() .. "OptionAchievements"):SetChecked(gw.settings:get('achievements', mode))
     getglobal(self:GetName() .. "OptionRoster"):SetChecked(gw.settings:get('roster', mode))
     getglobal(self:GetName() .. "OptionRank"):SetChecked(gw.settings:get('rank', mode))
     getglobal(self:GetName() .. "OptionJoinDelay"):SetValue(gw.settings:get('joindelay', mode))
@@ -77,8 +76,6 @@ function GreenWallInterfaceFrame_SaveUpdates(self)
     local mode = getglobal(self:GetName() .. "OptionMode"):GetChecked() and GW_MODE_ACCOUNT or GW_MODE_CHARACTER
     gw.settings:set('mode', mode)
     gw.settings:set('tag', getglobal(self:GetName() .. "OptionTag"):GetChecked() and true or false, mode)
-    gw.settings:set('achievements',
-        getglobal(self:GetName() .. "OptionAchievements"):GetChecked() and true or false, mode)
     gw.settings:set('roster', getglobal(self:GetName() .. "OptionRoster"):GetChecked() and true or false, mode)
     gw.settings:set('rank', getglobal(self:GetName() .. "OptionRank"):GetChecked() and true or false, mode)
     gw.settings:set('joindelay', getglobal(self:GetName() .. "OptionJoinDelay"):GetValue(), mode)

--- a/README.md
+++ b/README.md
@@ -123,12 +123,6 @@ You will be able to set the following options.
   
   Default: on
 
-- __achievements__ - _Show Co-Guild Achievement Announcements_
-
-  Show achievements from other co-guilds. 
-  
-  Default: off
-
 - __roster__ - _Show Co-Guild Roster Announcements_
 
   Show guild join and leave messages from other co-guilds. 
@@ -186,12 +180,6 @@ To view the current configuration, you would enter one of the following.
   Show co-guild identifier in messages. 
   
   Default: on
-
-- achievements [ on | off ]
-  
-  Show achievements from other co-guilds. 
-
-  Default: off
 
 - roster [ on | off ]
 
@@ -269,7 +257,7 @@ to establish communication with other co-guilds in a confederation.
 
 - Bridging
 
-  Replication of chat events within one guild into the guild, achievement, and officer chat of another guild.
+  Replication of chat events within one guild into the guild and officer chat of another guild.
 
 - Confederation
 

--- a/Settings.lua
+++ b/Settings.lua
@@ -61,10 +61,6 @@ function GwSettings:new()
             value = true,
             desc = "co-guild tagging"
         },
-        achievements = {
-            value = false,
-            desc = "co-guild achievement announcements"
-        },
         roster = {
             value = true,
             desc = "co-guild roster announcements"

--- a/tests/TestSettings.lua
+++ b/tests/TestSettings.lua
@@ -71,7 +71,6 @@ function TestSettingsCreate:test_initialize()
         lu.assertStrMatches(tab.created, '%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d')
         lu.assertStrMatches(tab.updated, '%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d')
         lu.assertEquals(tab.tag, true)
-        lu.assertEquals(tab.achievements, false)
         lu.assertEquals(tab.roster, true)
         lu.assertEquals(tab.rank, false)
         lu.assertEquals(tab.debug, GW_LOG_NONE)
@@ -96,7 +95,6 @@ function TestSettingsLoad:setUp()
     GreenWall = {
         created = "2018-01-01 17:28:47",
         updated = "2018-01-01 01:04:46",
-        achievements = true,
         roster = false,
     }
     GreenWallAccount = {
@@ -123,7 +121,6 @@ end
 function TestSettingsLoad:test_character()
     local settings = GwSettings:new()
     lu.assertEquals(GreenWall.tag, true)
-    lu.assertEquals(GreenWall.achievements, true)
     lu.assertEquals(GreenWall.roster, false)
     lu.assertEquals(GreenWall.rank, false)
 end
@@ -149,14 +146,12 @@ function TestSettingsAccess:setUp()
         created = "2018-01-01 17:28:47",
         updated = "2018-01-01 01:04:46",
         tag = true,
-        achievements = true,
         logsize = 1024,
     }
     GreenWallAccount = {
         created = "2018-01-01 17:28:47",
         updated = "2018-01-01 01:04:46",
         tag = false,
-        achievements = false,
         logsize = 2048,
     }
 end
@@ -167,22 +162,18 @@ function TestSettingsAccess:test_get()
     lu.assertEquals(settings:get('mode'), GW_MODE_ACCOUNT)
 
     lu.assertEquals(settings:get('tag'), false)
-    lu.assertEquals(settings:get('achievements'), false)
     lu.assertEquals(settings:get('logsize'), 2048)
 
     lu.assertEquals(settings:get('tag',GW_MODE_CHARACTER), true)
-    lu.assertEquals(settings:get('achievements', GW_MODE_CHARACTER), true)
     lu.assertEquals(settings:get('logsize', GW_MODE_CHARACTER), 1024)
 
     settings:set('mode', GW_MODE_CHARACTER)
     lu.assertEquals(settings:get('mode'), GW_MODE_CHARACTER)
 
     lu.assertEquals(settings:get('tag'), true)
-    lu.assertEquals(settings:get('achievements'), true)
     lu.assertEquals(settings:get('logsize'), 1024)
 
     lu.assertEquals(settings:get('tag', GW_MODE_ACCOUNT), false)
-    lu.assertEquals(settings:get('achievements', GW_MODE_ACCOUNT), false)
     lu.assertEquals(settings:get('logsize', GW_MODE_ACCOUNT), 2048)
 end
 


### PR DESCRIPTION
As Blizzard has made `SendChatMessage` a partially-protected method, non-hardware driven events (like achievements and loot announcements) cannot generate custom chat channel messges.

So, I'm pulling out the achievement and loot announcement code.  