### PR TITLE
Fix registering Options UI in Classic Era

### DIFF
--- a/GreenWall.lua
+++ b/GreenWall.lua
@@ -187,7 +187,10 @@ function GreenWall_OnLoad(self)
     self.default = function(self)
         GreenWallInterfaceFrame_SetDefaults(self)
     end
-    InterfaceOptions_AddCategory(self)
+
+    local category = Settings.RegisterCanvasLayoutCategory(self, self.name)
+    Settings.RegisterAddOnCategory(category)
+
 end
 
 


### PR DESCRIPTION
With the new update to SOD version, 1.15.4, the Classic Era and Hardcore were also updated one step closer to retail, and now the once deprecated InterfaceOptions* functions were dropped.

https://github.com/Gethe/wow-ui-source/blob/1.15.2/Interface/SharedXML/Settings/Blizzard_Deprecated.lua

https://github.com/Gethe/wow-ui-source/blob/live/Interface/AddOns/Blizzard_Settings_Shared/Blizzard_ImplementationReadme.lua

<img width="948" alt="image" src="https://github.com/user-attachments/assets/422819f9-bdf5-476e-a73f-f02c1d8238cf">
