### PR TITLE
branch and version bump for upcoming release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning](http://semver.org/).
 
 ## 1.11.18 -- 2024-08-23
 
+- Updated the TOC for WoW 11.2.5.
+
+## 1.11.18 -- 2024-08-23
+
 - Updated the TOC for WoW 11.2.0.
 
 ## 1.11.17 -- 2024-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project uses [Semantic Versioning](http://semver.org/).
 
-## 1.11.18 -- 2024-08-23
+## 1.11.19 -- 2024-08-23
 
 - Updated the TOC for WoW 11.2.5.
 

--- a/GreenWall.toc
+++ b/GreenWall.toc
@@ -1,15 +1,15 @@
-## Interface: 110200
+## Interface: 110205
 ## Title: GreenWall
 ## Notes: Common communication channel as a replacement for guild chat in guild confederations.
 ## Author: Mark Rogaski <stigg@aie-guild.org>
-## Version: 1.11.18
+## Version: 1.11.19
 ## URL: https://github.com/AIE-Guild/GreenWall
 ## URL: https://www.curseforge.com/wow/addons/greenwall
 ## DefaultState: enabled
 ## SavedVariables: GreenWallAccount
 ## SavedVariablesPerCharacter: GreenWall,GreenWallMeta,GreenWallLog
 ## X-Category: Guild
-## X-Date: 2025-08-23
+## X-Date: 2025-10-07
 
 Lib\Load.xml
 Constants.lua


### PR DESCRIPTION
Bumps the version of Greenwall for WoW The War Within 11.2.5 released on 2025.10.07