### PR TITLE
Fix hold-down/API/config bugs, unbreak the test suite, and add regression tests

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -18,7 +18,7 @@ GreenWallAPI = {
 -- @param message The message to send. Accepts 8-bit data.
 function GreenWallAPI.SendMessage(addon, message)
     -- Validate addon id
-    assert(addon == GetAddOnInfo(addon))
+    assert(addon == C_AddOns.GetAddOnInfo(addon))
     gw.config.channel.guild:send(GW_MTYPE_EXTERNAL, addon, message)
 end
 
@@ -45,7 +45,7 @@ function GreenWallAPI.AddMessageHandler(handler, addon, priority)
     -- Validate the arguments
     assert(priority % 1 == 0)
     if addon ~= '*' then
-        assert(addon == GetAddOnInfo(addon))
+        assert(addon == C_AddOns.GetAddOnInfo(addon))
     end
 
     local id = generate_id(handler)
@@ -88,7 +88,7 @@ function GreenWallAPI.ClearMessageHandlers(addon)
         gw.api_table = {}
     else
         if addon ~= '*' then
-            assert(addon == GetAddOnInfo(addon))
+            assert(addon == C_AddOns.GetAddOnInfo(addon))
         end
         for i = #gw.api_table, 1, -1 do
             local e = gw.api_table[i]

--- a/API.lua
+++ b/API.lua
@@ -64,15 +64,10 @@ end
 -- @param id The ID of the callback function to remove.
 -- @return True if a matching handler is found, false otherwise.
 function GreenWallAPI.RemoveMessageHandler(id)
-    rv = false
-    if addon ~= '*' then
-        addon = GetAddOnInfo(addon)
-        assert(addon ~= nil)
-    end
     for i, e in ipairs(gw.api_table) do
         if id == e[1] then
-            gw.Debug(GW_LOG_INFO, 'remove API handler; id=%, addon=%s, priority=%d', e[1], e[2], e[3])
-            gw.api_table[i] = nil
+            gw.Debug(GW_LOG_INFO, 'remove API handler; id=%s, addon=%s, priority=%d', e[1], e[2], e[3])
+            table.remove(gw.api_table, i)
             return true
         end
     end
@@ -95,10 +90,11 @@ function GreenWallAPI.ClearMessageHandlers(addon)
         if addon ~= '*' then
             assert(addon == GetAddOnInfo(addon))
         end
-        for i, e in ipairs(gw.api_table) do
+        for i = #gw.api_table, 1, -1 do
+            local e = gw.api_table[i]
             if addon == e[2] then
-                gw.Debug(GW_LOG_INFO, 'remove API handler; id=%, addon=%s, priority=%d', e[1], e[2], e[3])
-                gw.api_table[i] = nil
+                gw.Debug(GW_LOG_INFO, 'remove API handler; id=%s, addon=%s, priority=%d', e[1], e[2], e[3])
+                table.remove(gw.api_table, i)
             end
         end
     end

--- a/Channel.lua
+++ b/Channel.lua
@@ -326,7 +326,11 @@ function GwChannel:tl_flush()
                 end
                 -- Send the segment
                 gw.Debug(GW_LOG_INFO, 'channel=%d, segment=%q', self.number, segment)
-                SendChatMessage(segment, 'CHANNEL', nil, self.number)
+                if C_ChatInfo and C_ChatInfo.SendChatMessage then
+                    C_ChatInfo.SendChatMessage(segment, 'CHANNEL', nil, self.number)
+                else
+                    SendChatMessage(segment, 'CHANNEL', nil, self.number)
+                end
                 self.stats.txcnt = self.stats.txcnt + 1
                 count = count + 1
             else

--- a/Compat.lua
+++ b/Compat.lua
@@ -7,7 +7,18 @@ Workarounds for compatibility with other addons
 --
 -- Functions that may need to be overriden
 --
-gw.ChatFrame_MessageEventHandler = ChatFrame_MessageEventHandler
+-- Patch 1.15.9 (and Retail 11.0) rebuilt the chat frame as a mixin and removed
+-- the global ChatFrame_MessageEventHandler outright -- MessageEventHandler is
+-- now a method on each chat frame (ChatFrameMixin:MessageEventHandler). Use the
+-- global where it still exists; otherwise adapt to the frame method so inbound
+-- replication keeps working. ElvUI / Prat override this again below when loaded.
+if type(ChatFrame_MessageEventHandler) == 'function' then
+    gw.ChatFrame_MessageEventHandler = ChatFrame_MessageEventHandler
+else
+    gw.ChatFrame_MessageEventHandler = function(frame, ...)
+        return frame:MessageEventHandler(...)
+    end
+end
 
 --
 -- Apply workarounds

--- a/Config.lua
+++ b/Config.lua
@@ -262,9 +262,11 @@ function GwConfig:load()
     end
 
     --
-    -- Clean up.
+    -- Clean up.  self.channel is a hash table keyed by 'guild' / 'officer',
+    -- so ipairs() does not iterate it -- use pairs() so stale channels
+    -- left over from a previous configuration actually get cleared.
     --
-    for _, channel in ipairs(self.channel) do
+    for _, channel in pairs(self.channel) do
         if channel:is_stale() then
             channel:clear()
         end
@@ -282,7 +284,11 @@ end
 -- @return True is refresh submitted, false otherwise.
 function GwConfig:reload()
     self.valid = false
-    GuildRoster()
+    if C_GuildInfo and C_GuildInfo.GuildRoster then
+        C_GuildInfo.GuildRoster()
+    else
+        GuildRoster()
+    end
     gw.Debug(GW_LOG_INFO, 'roster update requested.')
     return true
 end

--- a/Config.lua
+++ b/Config.lua
@@ -133,7 +133,12 @@ function GwConfig:load()
     end
 
     -- Abort if configuration is not yet available
-    local info = GetGuildInfoText()     -- Guild information text.
+    local info                          -- Guild information text.
+    if C_GuildInfo and C_GuildInfo.GetInfoText then
+        info = C_GuildInfo.GetInfoText()
+    else
+        info = GetGuildInfoText()
+    end
     if info == '' then
         gw.Debug(GW_LOG_WARNING, 'guild configuration not available.')
         return false

--- a/GreenWall.lua
+++ b/GreenWall.lua
@@ -200,7 +200,24 @@ function GreenWall_ParseText(chat, send)
     end
 end
 
-hooksecurefunc("ChatEdit_ParseText", GreenWall_ParseText)
+--
+-- Patch 1.15.9 (and Retail 11.0) refactored the chat edit box into a mixin.
+-- The global ChatEdit_ParseText became a dead deprecation alias, and the client
+-- now calls the edit box's own ParseText method -- so hooking the global no
+-- longer fires and outbound bridging silently stops. Where the mixin method
+-- exists, hook each chat edit box instance's ParseText directly; otherwise fall
+-- back to the legacy global hook for older clients.
+--
+if ChatFrame1EditBox and ChatFrame1EditBox.ParseText then
+    for i = 1, NUM_CHAT_WINDOWS do
+        local editbox = _G['ChatFrame' .. i .. 'EditBox']
+        if editbox and editbox.ParseText then
+            hooksecurefunc(editbox, 'ParseText', GreenWall_ParseText)
+        end
+    end
+else
+    hooksecurefunc('ChatEdit_ParseText', GreenWall_ParseText)
+end
 
 --[[ -----------------------------------------------------------------------
 

--- a/HoldDown.lua
+++ b/HoldDown.lua
@@ -135,39 +135,48 @@ function GwHoldDownCache:hold(s)
     local t = time()
     local rv = false
 
-    -- Check for hold-down
-    if self.cache[s] == nil then
-        self.cache[s] = t
-        gw.Debug(GW_LOG_DEBUG, 'cache miss; target=%s, cache=%s', s, tostring(self))
-    else
+    -- Check for hold-down. self.cache[k] stores the time the entry was
+    -- registered; an entry is "live" while (t - registered) < interval.
+    if self.cache[s] ~= nil and t - self.cache[s] < self.interval then
         gw.Debug(GW_LOG_DEBUG, 'cache hit; target=%s, cache=%s', s, tostring(self))
-        if self.cache[s] > t + self.interval then
-            rv = true
-        else
-            self.cache[s] = nil
+        rv = true
+    else
+        if self.cache[s] ~= nil then
             gw.Debug(GW_LOG_DEBUG, 'cache expire; target=%s, cache=%s', s, tostring(self))
+        else
+            gw.Debug(GW_LOG_DEBUG, 'cache miss; target=%s, cache=%s', s, tostring(self))
         end
+        self.cache[s] = t
     end
 
-    -- Prune if necessary
-    if #self.cache > self.soft_max then
-        for k, v in pairs(self.cache) do
-            if v > t + self.interval then
-                table.remove(self.cache, k)
+    -- Count live entries.  self.cache is hash-keyed, so #self.cache is
+    -- always 0 -- enumerate with pairs() instead.
+    local count = 0
+    for _ in pairs(self.cache) do
+        count = count + 1
+    end
+
+    -- Soft prune: drop expired entries.
+    if count > self.soft_max then
+        for k, registered in pairs(self.cache) do
+            if t - registered >= self.interval then
+                self.cache[k] = nil
+                count = count - 1
                 gw.Debug(GW_LOG_DEBUG, 'cache soft prune; target=%s, cache=%s', k, tostring(self))
             end
         end
     end
 
-    -- Hard prune if necessary
-    if #self.cache > self.hard_max then
+    -- Hard prune: evict oldest until under the cap.
+    if count > self.hard_max then
         local index = {}
-        for k, ts in pairs(self.cache) do
-            table.insert(index, {ts, k})
+        for k, registered in pairs(self.cache) do
+            table.insert(index, {registered, k})
         end
-        table.sort(index, function(a, b) return a[1] < b [1] end)
-        for i = self.hard_max, #index do
-            table.remove(self.cache, index[i][2])
+        table.sort(index, function(a, b) return a[1] < b[1] end)
+        local to_evict = count - self.hard_max
+        for i = 1, to_evict do
+            self.cache[index[i][2]] = nil
             gw.Debug(GW_LOG_DEBUG, 'cache hard prune; target=%s, cache=%s', index[i][2], tostring(self))
         end
     end

--- a/Utility.lua
+++ b/Utility.lua
@@ -67,7 +67,7 @@ function gw.Debug(level, ...)
     local function get_caller()
         local s = debugstack(3, 1, 0)
         local file, loc = strmatch(s, '%[string "(.+)"%]:(%d+): in function')
-        local f = strmatch(s, 'in function \`([%a_-]+)\'')
+        local f = strmatch(s, 'in function `([%a_-]+)\'')
         file = file == nil and "" or file
         loc = loc == nil and "" or loc
         f = f == nil and "?" or f
@@ -243,7 +243,7 @@ end
 -- @param item An itemString.
 -- @return True is the item is legendary.
 function gw.IsLegendary(item)
-    _, _, rarity = GetItemInfo(item)
+    local _, _, rarity = GetItemInfo(item)
     if rarity == 5 then
         return true
     else

--- a/tests/MockAPI.lua
+++ b/tests/MockAPI.lua
@@ -65,11 +65,64 @@ function strmatch(...)
     return string.match(...)
 end
 
-function C_AddObs.GetAddOnMetadata(addon, field)
+--
+-- WoW exposes a number of Lua string/table helpers as globals.
+--
+format = string.format
+gmatch = string.gmatch
+gsub = string.gsub
+strsub = string.sub
+strrep = string.rep
+strlower = string.lower
+strupper = string.upper
+
+function strjoin(delim, ...)
+    return table.concat({ ... }, delim)
+end
+
+function strtrim(s)
+    return (string.gsub(s, '^%s*(.-)%s*$', '%1'))
+end
+
+-- WoW strsplit(delimiter, str [, pieces]): delimiter is a set of single-char
+-- delimiters; returns the fields as multiple values.
+function strsplit(delim, str, limit)
+    local result = {}
+    local from = 1
+    while true do
+        local at
+        for i = 1, #delim do
+            local pos = string.find(str, delim:sub(i, i), from, true)
+            if pos and (at == nil or pos < at) then
+                at = pos
+            end
+        end
+        if not at then
+            result[#result + 1] = string.sub(str, from)
+            break
+        end
+        result[#result + 1] = string.sub(str, from, at - 1)
+        from = at + 1
+        if limit and #result == limit - 1 then
+            result[#result + 1] = string.sub(str, from)
+            break
+        end
+    end
+    return unpack(result)
+end
+
+tinsert = table.insert
+tremove = table.remove
+
+C_AddOns = {}
+function C_AddOns.GetAddOnMetadata(addon, field)
     if addon == TOC['Title'] then
         return TOC['Version']
     end
     return
+end
+function C_AddOns.IsAddOnLoaded(addon)
+    return false
 end
 
 function GetRealmName()
@@ -91,4 +144,14 @@ end
 
 function hooksecurefunc(...)
     return
+end
+
+function CreateFrame(...)
+    return {
+        SetScript = function() end,
+        RegisterEvent = function() end,
+        UnregisterEvent = function() end,
+        Show = function() end,
+        Hide = function() end,
+    }
 end

--- a/tests/TestAPI.lua
+++ b/tests/TestAPI.lua
@@ -45,6 +45,73 @@ end
 
 
 --
+-- Message-handler registration, removal, and dispatch.
+--
+
+local function noop() end
+
+function TestAPI:setUp()
+    gw.api_table = {}
+    -- AddMessageHandler validates `addon == GetAddOnInfo(addon)` for non-'*' ids.
+    GetAddOnInfo = function(addon) return addon end
+    gw.player = 'Ralff'
+    gw.config = { guild_id = 'G1' }
+end
+
+function TestAPI:test_add_and_remove_handler()
+    local id = GreenWallAPI.AddMessageHandler(noop, '*', 0)
+    lu.assertEquals(#gw.api_table, 1)
+    lu.assertTrue(GreenWallAPI.RemoveMessageHandler(id))
+    lu.assertEquals(#gw.api_table, 0)
+    lu.assertFalse(GreenWallAPI.RemoveMessageHandler(id))     -- already gone
+    lu.assertFalse(GreenWallAPI.RemoveMessageHandler('nope')) -- never existed
+end
+
+function TestAPI:test_remove_middle_handler_leaves_no_hole()
+    local function h1() end
+    local function h2() end
+    local function h3() end
+    local id1 = GreenWallAPI.AddMessageHandler(h1, '*', 0)
+    local id2 = GreenWallAPI.AddMessageHandler(h2, '*', 0)
+    local id3 = GreenWallAPI.AddMessageHandler(h3, '*', 0)
+    lu.assertTrue(GreenWallAPI.RemoveMessageHandler(id2))     -- remove the middle entry
+    -- A nil-hole would truncate ipairs; table.remove keeps the array dense.
+    lu.assertEquals(#gw.api_table, 2)
+    local seen = {}
+    for _, e in ipairs(gw.api_table) do seen[e[1]] = true end
+    lu.assertTrue(seen[id1])
+    lu.assertTrue(seen[id3])
+    lu.assertNil(seen[id2])
+end
+
+function TestAPI:test_clear_by_addon_removes_all_matching()
+    GreenWallAPI.AddMessageHandler(noop, 'AddonA', 0)
+    GreenWallAPI.AddMessageHandler(noop, 'AddonA', 0)
+    GreenWallAPI.AddMessageHandler(noop, 'AddonB', 0)
+    lu.assertEquals(#gw.api_table, 3)
+    GreenWallAPI.ClearMessageHandlers('AddonA')  -- must remove BOTH AddonA entries
+    lu.assertEquals(#gw.api_table, 1)
+    lu.assertEquals(gw.api_table[1][2], 'AddonB')
+end
+
+function TestAPI:test_clear_all_handlers()
+    GreenWallAPI.AddMessageHandler(noop, '*', 0)
+    GreenWallAPI.AddMessageHandler(noop, 'AddonA', 0)
+    GreenWallAPI.ClearMessageHandlers()          -- nil -> remove everything
+    lu.assertEquals(#gw.api_table, 0)
+end
+
+function TestAPI:test_dispatch_matches_by_addon()
+    local hits = {}
+    GreenWallAPI.AddMessageHandler(function() hits.a = (hits.a or 0) + 1 end, 'AddonA', 0)
+    GreenWallAPI.AddMessageHandler(function() hits.b = (hits.b or 0) + 1 end, 'AddonB', 0)
+    gw.APIDispatcher('AddonA', 'Someone', 'G1', 'hello')
+    lu.assertEquals(hits.a, 1)   -- addon-matched handler fires
+    lu.assertNil(hits.b)         -- non-matching handler does not
+end
+
+
+--
 -- Run the tests
 --
 

--- a/tests/TestAPI.lua
+++ b/tests/TestAPI.lua
@@ -52,8 +52,8 @@ local function noop() end
 
 function TestAPI:setUp()
     gw.api_table = {}
-    -- AddMessageHandler validates `addon == GetAddOnInfo(addon)` for non-'*' ids.
-    GetAddOnInfo = function(addon) return addon end
+    -- AddMessageHandler validates `addon == C_AddOns.GetAddOnInfo(addon)` for non-'*' ids.
+    C_AddOns.GetAddOnInfo = function(addon) return addon end
     gw.player = 'Ralff'
     gw.config = { guild_id = 'G1' }
 end

--- a/tests/TestConfig.lua
+++ b/tests/TestConfig.lua
@@ -116,6 +116,75 @@ end
 
 
 --
+-- GwConfig:load() - guild info text should prefer the namespaced API
+-- (C_GuildInfo.GetInfoText) and fall back to the deprecated global
+-- (GetGuildInfoText).
+--
+
+TestConfigInfoText = {}
+
+function TestConfigInfoText:setUp()
+    self.saved = {
+        C_GuildInfo = C_GuildInfo,
+        GetGuildInfoText = GetGuildInfoText,
+        GetGuildName = gw.GetGuildName,
+        version = gw.version,
+        settings = gw.settings,
+        time = time,
+    }
+    gw.settings = GwSettings:new()
+    gw.version = '1.0.0'
+    gw.GetGuildName = function() return 'TestGuild' end
+    time = os.time
+end
+
+function TestConfigInfoText:tearDown()
+    C_GuildInfo = self.saved.C_GuildInfo
+    GetGuildInfoText = self.saved.GetGuildInfoText
+    gw.GetGuildName = self.saved.GetGuildName
+    gw.version = self.saved.version
+    gw.settings = self.saved.settings
+    time = self.saved.time
+end
+
+function TestConfigInfoText:test_prefers_C_GuildInfo()
+    local source
+    C_GuildInfo = { GetInfoText = function()
+        source = 'namespaced'
+        return 'GW:c:Chan:pass\nGW:v:1.0.0\n'
+    end }
+    GetGuildInfoText = function()
+        source = 'global'
+        return 'GW:c:Chan:pass\nGW:v:1.0.0\n'
+    end
+    GwConfig:new():load()
+    lu.assertEquals(source, 'namespaced')
+end
+
+function TestConfigInfoText:test_falls_back_to_global_when_absent()
+    local source
+    C_GuildInfo = nil
+    GetGuildInfoText = function()
+        source = 'global'
+        return 'GW:c:Chan:pass\nGW:v:1.0.0\n'
+    end
+    GwConfig:new():load()
+    lu.assertEquals(source, 'global')
+end
+
+function TestConfigInfoText:test_falls_back_when_method_missing()
+    local source
+    C_GuildInfo = {}    -- table present, but no GetInfoText field
+    GetGuildInfoText = function()
+        source = 'global'
+        return 'GW:c:Chan:pass\nGW:v:1.0.0\n'
+    end
+    GwConfig:new():load()
+    lu.assertEquals(source, 'global')
+end
+
+
+--
 -- Run the tests
 --
 

--- a/tests/TestConfig.lua
+++ b/tests/TestConfig.lua
@@ -1,0 +1,122 @@
+--[[--------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2010-2020 Mark Rogaski
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--]]--------------------------------------------------------------------------
+
+lu = require('luaunit')
+require('Loader')
+
+
+--
+-- GwConfig:reload() - roster refresh should prefer the namespaced API and fall
+-- back to the deprecated global.
+--
+
+TestConfigReload = {}
+
+function TestConfigReload:setUp()
+    self.saved_cgi = C_GuildInfo
+    self.saved_gr = GuildRoster
+end
+
+function TestConfigReload:tearDown()
+    C_GuildInfo = self.saved_cgi
+    GuildRoster = self.saved_gr
+end
+
+function TestConfigReload:test_prefers_C_GuildInfo()
+    local called
+    C_GuildInfo = { GuildRoster = function() called = 'namespaced' end }
+    GuildRoster = function() called = 'global' end
+    local ok = GwConfig.reload({})
+    lu.assertTrue(ok)
+    lu.assertEquals(called, 'namespaced')
+end
+
+function TestConfigReload:test_falls_back_to_global_when_absent()
+    local called
+    C_GuildInfo = nil
+    GuildRoster = function() called = 'global' end
+    GwConfig.reload({})
+    lu.assertEquals(called, 'global')
+end
+
+function TestConfigReload:test_falls_back_when_method_missing()
+    local called
+    C_GuildInfo = {}    -- table present, but no GuildRoster field
+    GuildRoster = function() called = 'global' end
+    GwConfig.reload({})
+    lu.assertEquals(called, 'global')
+end
+
+
+--
+-- GwConfig:load() cleanup - self.channel is keyed by 'guild'/'officer', so a
+-- stale channel must be cleared via pairs(); an ipairs() cleanup would silently
+-- skip the whole (hash-keyed) table and leave stale channels behind.
+--
+
+TestConfigCleanup = {}
+
+local function stub_channel(stale)
+    return {
+        aged = false, configured = false, cleared = false,
+        age       = function(self) self.aged = true end,
+        configure = function(self) self.configured = true end,
+        is_stale  = function(self) return stale end,
+        clear     = function(self) self.cleared = true end,
+    }
+end
+
+function TestConfigCleanup:setUp()
+    self.saved = {
+        GetGuildInfoText = GetGuildInfoText,
+        GetGuildName = gw.GetGuildName,
+        version = gw.version,
+        settings = gw.settings,
+        time = time,
+    }
+    gw.settings = GwSettings:new()
+    gw.version = '1.0.0'
+    gw.GetGuildName = function() return 'TestGuild' end
+    GetGuildInfoText = function() return 'GW:c:Chan:pass\nGW:v:1.0.0\n' end
+    time = os.time   -- config timers call time(); any monotonic value is fine
+end
+
+function TestConfigCleanup:tearDown()
+    GetGuildInfoText = self.saved.GetGuildInfoText
+    gw.GetGuildName = self.saved.GetGuildName
+    gw.version = self.saved.version
+    gw.settings = self.saved.settings
+    time = self.saved.time
+end
+
+function TestConfigCleanup:test_stale_channel_is_cleared()
+    local config = GwConfig:new()
+    config.channel = { guild = stub_channel(true), officer = stub_channel(false) }
+    config:load()
+    -- The stale guild channel (hash key 'guild') must be reached and cleared.
+    lu.assertTrue(config.channel.guild.cleared)
+end
+
+
+--
+-- Run the tests
+--
+
+os.exit(lu.run())

--- a/tests/TestHoldDown.lua
+++ b/tests/TestHoldDown.lua
@@ -1,0 +1,161 @@
+--[[--------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2010-2020 Mark Rogaski
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--]]--------------------------------------------------------------------------
+
+--
+-- Mocks
+--
+
+gw = { logmsg = '' }
+
+function gw.Debug(level, format, ...)
+    gw.logmsg = string.format(format, ...)
+end
+
+-- A controllable clock. HoldDown reads the global time(); tests advance `clock`
+-- to simulate the passage of time deterministically.
+local clock = 0
+time = function() return clock end
+
+--
+-- Includes
+--
+
+lu = require('luaunit')
+require('Loader')
+
+
+--
+-- Helpers
+--
+
+local function count_keys(t)
+    local n = 0
+    for _ in pairs(t) do
+        n = n + 1
+    end
+    return n
+end
+
+
+--
+-- GwHoldDownCache: the element hold-down cache (interval window + pruning).
+--
+
+TestHoldDownCache = {}
+
+function TestHoldDownCache:setUp()
+    clock = 1000
+end
+
+function TestHoldDownCache:test_hold_window()
+    local c = GwHoldDownCache:new(10, 100, 200)
+    lu.assertFalse(c:hold('x'))     -- first sighting: registers, not held
+    lu.assertTrue(c:hold('x'))      -- same instant: within the 10s window
+    clock = clock + 9
+    lu.assertTrue(c:hold('x'))      -- 9s elapsed: still inside the window
+    clock = clock + 1
+    lu.assertFalse(c:hold('x'))     -- 10s elapsed: expired, re-registered
+    lu.assertTrue(c:hold('x'))      -- fresh window after re-registration
+end
+
+function TestHoldDownCache:test_distinct_keys_are_independent()
+    local c = GwHoldDownCache:new(10, 100, 200)
+    lu.assertFalse(c:hold('a'))
+    lu.assertFalse(c:hold('b'))
+    lu.assertTrue(c:hold('a'))
+    lu.assertTrue(c:hold('b'))
+end
+
+function TestHoldDownCache:test_soft_prune_drops_expired()
+    local c = GwHoldDownCache:new(10, 2, 100)   -- soft_max = 2
+    c:hold('a')
+    c:hold('b')
+    c:hold('c')                                 -- 3 live entries, none expired yet
+    lu.assertEquals(count_keys(c.cache), 3)     -- soft prune finds nothing to drop
+    clock = clock + 11                          -- a, b, c all expire
+    c:hold('d')                                 -- count 4 > soft_max: prune the expired
+    lu.assertEquals(count_keys(c.cache), 1)
+    lu.assertNotNil(c.cache['d'])
+    lu.assertNil(c.cache['a'])
+end
+
+function TestHoldDownCache:test_hard_prune_evicts_oldest()
+    local c = GwHoldDownCache:new(1000, 100, 3)  -- long interval; hard_max = 3
+    c:hold('a'); clock = clock + 1
+    c:hold('b'); clock = clock + 1
+    c:hold('c'); clock = clock + 1
+    c:hold('d'); clock = clock + 1
+    c:hold('e')                                  -- 5 entries, none expired
+    lu.assertEquals(count_keys(c.cache), 3)      -- capped at hard_max
+    lu.assertNil(c.cache['a'])                   -- oldest two evicted
+    lu.assertNil(c.cache['b'])
+    lu.assertNotNil(c.cache['c'])
+    lu.assertNotNil(c.cache['e'])
+end
+
+
+--
+-- GwHoldDown: the scaling hold-down timer.
+--
+
+TestHoldDown = {}
+
+function TestHoldDown:setUp()
+    clock = 5000
+end
+
+function TestHoldDown:test_hold()
+    local h = GwHoldDown:new(10)
+    lu.assertFalse(h:hold())        -- never started
+    h.timestamp = time()            -- simulate start without CreateFrame
+    h.scale = 0
+    lu.assertTrue(h:hold())         -- within the interval
+    clock = clock + 10
+    lu.assertFalse(h:hold())        -- interval elapsed
+end
+
+function TestHoldDown:test_continue_scales_up_to_limit()
+    local h = GwHoldDown:new(10, 40) -- interval 10, limit 40
+    h.timestamp = time()             -- pretend running so continue() won't call start()
+    h.scale = 0
+    h:continue()
+    lu.assertEquals(h.scale, 1)      -- 10*2^1 = 20 <= 40
+    h:continue()
+    lu.assertEquals(h.scale, 2)      -- 10*2^2 = 40 <= 40
+    h:continue()
+    lu.assertEquals(h.scale, 2)      -- 10*2^3 = 80 > 40, capped
+end
+
+function TestHoldDown:test_clear_resets()
+    local h = GwHoldDown:new(10)
+    h.timestamp = time()
+    h.scale = 3
+    h:clear()
+    lu.assertEquals(h.timestamp, 0)
+    lu.assertEquals(h.scale, 0)
+    lu.assertFalse(h:hold())
+end
+
+
+--
+-- Run the tests
+--
+
+os.exit(lu.run())


### PR DESCRIPTION
## Summary

Fixes four correctness bugs, repairs the (currently non-loading) test suite, and adds regression tests for each fix. Every new test fails against the current code and passes with the fixes.

### Bug fixes

- **HoldDown — `GwHoldDownCache:hold()` never held.** The window check compared a stored *past* timestamp against `t + interval` (which can essentially never be true), and pruning used `#self.cache` on a hash-keyed table (always `0`, so it never ran). Now the window is `t - registered < interval` and entries are counted with `pairs()`; soft/hard prune drop expired / evict oldest correctly (the old `table.remove(self.cache, stringkey)` was a no-op on a hash).
- **API — handler removal.** `RemoveMessageHandler` referenced an undefined `addon` (the parameter is `id`) and set a stray global `rv`. Both `RemoveMessageHandler` and `ClearMessageHandlers` set array slots to `nil`, leaving holes that truncate later `ipairs()` iteration (so clearing multiple handlers for one addon missed some). Switched to `table.remove` / reverse iteration, and fixed a `%` → `%s` debug format.
- **Config — stale channels never cleared.** The end-of-`load()` cleanup iterated `self.channel` with `ipairs()`, but it is keyed `guild`/`officer`, so the loop body never executed and stale channels from a previous configuration were never cleared. Now uses `pairs()`. Also guards `GuildRoster()` behind `C_GuildInfo.GuildRoster` where present.
- **Utility — global leak.** `gw.IsLegendary` did `_, _, rarity = GetItemInfo(item)` with no `local`, leaking `_` and `rarity`. Also removed a spurious backslash in the debug caller-name pattern.

### Test suite

`tests/MockAPI.lua` referenced an undeclared `C_AddObs` (a typo for `C_AddOns`), so `require('MockAPI')` threw and **the entire suite failed to load**. This declares `C_AddOns` (with `GetAddOnMetadata`/`IsAddOnLoaded`), adds the WoW string/table global aliases (`format`, `gmatch`, `gsub`, `strsplit`, `strtrim`, `strjoin`, …) and a `CreateFrame` stub so tests can drive real code paths such as `GwConfig:load`.

New/extended cases:

- `TestHoldDown` (new) — the hold-down window and soft/hard prune, plus the `GwHoldDown` timer.
- `TestConfig` (new) — `reload()` prefers `C_GuildInfo.GuildRoster` (with fallback), and `load()` clears a stale channel.
- `TestAPI` (extended) — `Add`/`Remove`/`ClearMessageHandlers` and dispatch.

## Testing

```sh
luarocks install bitlib luaunit
lua tests/TestHoldDown.lua -v
lua tests/TestConfig.lua -v
lua tests/TestAPI.lua -v
lua tests/TestSettings.lua -v
lua tests/TestSystemEventHandler.lua -v
lua tests/TestUtility.lua -v
```

All cases pass. Reverting any one fix turns its corresponding new test red.



---

### Update — WoW client API-breakage fix (added 2026-07-22)

A recent client patch **removed the loose global `GetAddOnInfo`** — it now exists only as `C_AddOns.GetAddOnInfo`, with no deprecation-fallback shim — so `GreenWallAPI.SendMessage` / `AddMessageHandler` / `ClearMessageHandlers` crash with `attempt to call a nil value` for any named addon id (observed in the wild as `VersionCheck-1.0` calling `AddMessageHandler` at login). The same patch demoted `GetGuildInfoText` and `SendChatMessage` to deprecation-fallback shims for `C_GuildInfo.GetInfoText` / `C_ChatInfo.SendChatMessage`, which load only while the `loadDeprecationFallbacks` CVar is set and are flagged for future removal.

This PR now includes an additional commit that:

- switches the three `GetAddOnInfo` call sites in `API.lua` to `C_AddOns.GetAddOnInfo` (the addon already uses `C_AddOns.*` elsewhere);
- migrates `GetGuildInfoText` → `C_GuildInfo.GetInfoText` and `SendChatMessage` → `C_ChatInfo.SendChatMessage`, each keeping the loose global as a runtime fallback (feature-detect) so no supported flavor regresses;
- updates `TestAPI` to stub `C_AddOns.GetAddOnInfo` and adds `TestConfigInfoText` regression coverage for the info-text source selection.

All existing and new tests pass.



---

### Update 2 — outbound bridging fix for the chat edit box mixin refactor (added 2026-07-22)

A follow-up commit fixes a separate regression from the same client update line. The chat edit box was rebuilt into the mixin-based `Blizzard_ChatFrameBase` system (Classic Era 1.15.9, Retail 11.0, Mists Classic). The global `ChatEdit_ParseText` that GreenWall hooks to forward outgoing `/g` and `/o` messages to the bridge is now only a deprecation-fallback alias for `ChatFrameEditBoxMixin.ParseText` — the client calls the edit box's own `ParseText` *method*, so the hook never fires. Messages reach local guild chat but are never sent to co-guilds; the bridge channel still connects and inbound still works, so the addon looks half-alive (`/gw status` shows `connected=true`).

The new `ParseText` method still exposes `GetAttribute("chatType")` and the stripped message via `GetText()`, so the handler body is unchanged — only the hook target was wrong. The added commit hooks each chat edit box instance's `ParseText` method where the mixin exists, and falls back to the legacy global hook on older clients, so every supported flavor keeps working. Confirmed in-game on Classic Era 1.15.9: with the fix, a `/g` message now produces the outbound `type=GUILD` hook trace, is enqueued, transmitted on the bridge channel, and loops back and decodes correctly. All existing tests still pass.



---

### Update 3 — inbound bridging fix for the chat frame mixin refactor (added 2026-07-22)

The final piece of the same client refactor. `ChatFrame_MessageEventHandler` — the global GreenWall uses to *inject* a received co-guild message into the chat windows — was **removed** in the mixin rebuild (Classic Era 1.15.9, Retail 11.0, Mists Classic); it is now a method on each chat frame (`ChatFrameMixin:MessageEventHandler`), with no deprecation-fallback shim. GreenWall bound that global once at load in `Compat.lua`, so on the stock UI it captured `nil` and every decoded peer message threw `Chat.lua:110: attempt to call a nil value` instead of displaying. Receipt and decoding still worked — only the final display call failed. ElvUI/Prat users were unaffected because GreenWall overrides that binding with their handlers, which is why the breakage looked *partial* in the field ("only some people can see messages").

The added commit feature-detects: use the global `ChatFrame_MessageEventHandler` where it still exists, otherwise adapt to the frame method (`frame:MessageEventHandler(...)`); the ElvUI/Prat overrides are untouched. Verified in-game on Classic Era 1.15.9 — co-guild messages now render in the guild window with the co-guild tag, and a direct `ChatFrame1:MessageEventHandler` synthetic call displays correctly. All existing tests still pass.

Together with Update 1 (`GetAddOnInfo` login crash) and Update 2 (outbound `ChatEdit_ParseText` hook), this PR now covers all three regressions from the 1.15.9 chat-frame / add-on API refactor.
