### PR TITLE
Fix guild chat replication on client 1.15.9 (ChatFrame_MessageEventHandler removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project uses [Semantic Versioning](http://semver.org/).
 
+## 1.11.23 -- 2026-07-25
+
+- Fixed guild chat replication on WoW Classic 1.15.9, which removed the ChatFrame_MessageEventHandler global.
+
 ## 1.11.22 -- 2026-07-22
 
 - Updated TOC for WoW Classic 1.15.9.

--- a/Compat.lua
+++ b/Compat.lua
@@ -7,7 +7,11 @@ Workarounds for compatibility with other addons
 --
 -- Functions that may need to be overriden
 --
-gw.ChatFrame_MessageEventHandler = ChatFrame_MessageEventHandler
+-- Client 1.15.9 removed the ChatFrame_MessageEventHandler global; the handler
+-- is now a method on the chat frame (ChatFrameMixin:MessageEventHandler).
+gw.ChatFrame_MessageEventHandler = ChatFrame_MessageEventHandler or function(frame, event, ...)
+    return frame:MessageEventHandler(event, ...)
+end
 
 --
 -- Apply workarounds

--- a/GreenWall.toc
+++ b/GreenWall.toc
@@ -2,14 +2,14 @@
 ## Title: GreenWall
 ## Notes: Common communication channel as a replacement for guild chat in guild confederations.
 ## Author: Mark Rogaski <stigg@aie-guild.org>
-## Version: 1.11.22+classic-era
+## Version: 1.11.23+classic-era
 ## URL: https://github.com/AIE-Guild/GreenWall
 ## URL: https://www.curseforge.com/wow/addons/greenwall
 ## DefaultState: enabled
 ## SavedVariables: GreenWallAccount
 ## SavedVariablesPerCharacter: GreenWall,GreenWallMeta,GreenWallLog
 ## X-Category: Guild
-## X-Date: 2026-07-22
+## X-Date: 2026-07-25
 
 Lib\Load.xml
 Constants.lua


### PR DESCRIPTION
Fixes #253.

Client 1.15.9 picked up the modern chat frame refactor from retail: the global `ChatFrame_MessageEventHandler` no longer exists, it is now a method on the chat frame mixin (`ChatFrameMixin:MessageEventHandler`). `Compat.lua` captured the global at load time, assigning nil, so `gw.ReplicateMessage` crashed with "attempt to call a nil value" at `Chat.lua:88` on every message received from a co-guild.

This change makes the assignment fall back to dispatching through the frame method when the global is absent:

```lua
gw.ChatFrame_MessageEventHandler = ChatFrame_MessageEventHandler or function(frame, event, ...)
    return frame:MessageEventHandler(event, ...)
end
```

Notes:

* On clients that still have the global (classic progression, older era builds), behavior is unchanged.
* The ElvUI and Prat-3.0 overrides in `gw.EnableCompatibility()` are unaffected since they run later and replace the function wholesale.
* Chosen over porting the shim from `main` (which redispatches via `frame:GetScript("OnEvent")`) because this preserves the exact old semantics: only the message handler runs, not the full OnEvent pipeline.
* Verified in-game on a 1.15.9 Anniversary realm: co-guild chat replicates again without errors, with the fallback confirmed to take the frame-method path when the global is absent and the legacy path when present.
* The luaunit suite in `tests/` currently fails on a pristine checkout of this branch (`MockAPI.lua:36: attempt to index global 'f'`, before any addon file loads), so it could not be used to validate this change.
