### PR TITLE
Fix Interface Options panel not saving changes

### DIFF
--- a/GreenWall.lua
+++ b/GreenWall.lua
@@ -164,6 +164,24 @@ function GreenWall_OnLoad(self)
 
     local category = Settings.RegisterCanvasLayoutCategory(self, self.name)
     Settings.RegisterAddOnCategory(category)
+
+    -- Settings.RegisterCanvasLayoutCategory (unlike the removed
+    -- InterfaceOptions_AddCategory it replaced) never calls self.okay,
+    -- self.cancel, or self.refresh - those belonged to the old panel
+    -- container's Okay/Cancel button flow. None of this panel's controls
+    -- have their own save-on-change handler, so every checkbox/slider here
+    -- visually toggles but GreenWallInterfaceFrame_SaveUpdates is never
+    -- invoked, meaning changes are silently discarded. Save immediately on
+    -- interaction instead, matching how the new Settings API expects
+    -- panels to behave.
+    local function GwSaveOnChange()
+        GreenWallInterfaceFrame_SaveUpdates(GreenWallInterfaceFrame)
+    end
+    GreenWallInterfaceFrameOptionMode:HookScript('OnClick', GwSaveOnChange)
+    GreenWallInterfaceFrameOptionTag:HookScript('OnClick', GwSaveOnChange)
+    GreenWallInterfaceFrameOptionRoster:HookScript('OnClick', GwSaveOnChange)
+    GreenWallInterfaceFrameOptionOfficerChat:HookScript('OnClick', GwSaveOnChange)
+    GreenWallInterfaceFrameOptionJoinDelay:HookScript('OnValueChanged', GwSaveOnChange)
 end
 
 


### PR DESCRIPTION
## Summary

None of the controls in the GreenWall Interface Options panel (Interface Options > AddOns > GreenWall) actually persist a change - toggling "Show co-guild tags", "Show co-guild roster announcements", "Officer Chat", the Account/Character mode checkbox, or dragging the join-delay slider all visually update the widget, but closing the panel discards the change. The only way to change these settings is via `/gw <setting> on|off`.

## Root cause

`GreenWall_OnLoad` (`GreenWall.lua`) registers the options panel via the modern `Settings.RegisterCanvasLayoutCategory` API, but still assigns `self.okay`/`self.cancel`/`self.refresh` - the callback convention from the old, removed `InterfaceOptions_AddCategory` panel system (the one with explicit Okay/Cancel buttons). The new Settings API never reads or invokes those fields, since panels are expected to persist changes immediately rather than waiting for an "Okay" commit step.

`GreenWallInterfaceFrame_SaveUpdates` (`Interface.lua`), which reads all the widgets and calls `gw.settings:set(...)`, is only ever wired up as `self.okay`, so it's never actually invoked anymore. None of the individual XML controls (`GreenWall.xml`) have their own save-on-change handler either - only the mode checkbox and the join-delay slider have any script at all, and those only refresh other widgets' *displayed* values or update the slider's label text, without saving.

This looks like a side effect of #252 ("Removed unsupported functions InterfaceOptions_AddCategory..."), which removed the old panel container that used to invoke `self.okay` for you, without adding an equivalent save trigger for the new API.

## Fix

Hook each control to call `GreenWallInterfaceFrame_SaveUpdates` immediately on change, matching how the new Settings API expects panels to behave. `GreenWallInterfaceFrame_SaveUpdates` already reads and saves every widget's current state in one pass, so it's safe to call from any single control's change handler.

## Test plan

- [x] Syntax-checked with `lua -e "local chunk, err = loadfile('GreenWall.lua'); print(chunk and 'OK' or err)"`
- [x] Verified locally in-game (Classic Era, same panel wiring) that toggling each control now persists across closing/reopening the panel and across `/reload`, without needing any `/gw` slash command