### PR TITLE
Fix eight defects found offline, and unbreak the test suite

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -123,7 +123,12 @@ function gw.APIDispatcher(addon, sender, guild_id, message)
     local echo = sender == gw.player
     local guild = guild_id == gw.config.guild_id
     for _, e in ipairs(gw.api_table) do
-        if addon == e[2] or addon == '*' then
+        -- The wildcard belongs to the REGISTRATION, not to the sender: e[2] is the addon the
+        -- handler asked to hear from, and '*' there means "all of them" (API.md).  Testing
+        -- `addon == '*'` instead asked whether the SENDER was literally named '*', which
+        -- AddMessageHandler's and SendMessage's own asserts make impossible -- so no handler
+        -- registered with '*' had ever been dispatched to.
+        if addon == e[2] or e[2] == '*' then
             gw.Debug(GW_LOG_INFO, 'dispatch API handler; id=%s, addon=%s, priority=%d', e[1], e[2], e[3])
             e[4](addon, sender, message, echo, guild)
         end

--- a/Channel.lua
+++ b/Channel.lua
@@ -166,14 +166,25 @@ function GwChannel:join()
             --
             -- Hide the channel
             --
-            for i = 1, 10 do
-                GwChannel.frame_table = { GetChatWindowMessages(i) }
-                for j, v in ipairs(GwChannel.frame_table) do
-                    if v == self.name then
-                        local frame = format('ChatFrame%d', i)
-                        if _G[frame] then
+            -- GetChatWindowChannels, not GetChatWindowMessages: the two are different lists, and
+            -- Blizzard reads them into RegisterForChannels and RegisterForMessages respectively
+            -- (Blizzard_ChatFrameBase/Classic/ChatFrameOverrides.lua:57-58). Messages holds
+            -- message-GROUP names ('GUILD', 'SAY'), which can never equal a channel name -- so
+            -- scanning it meant this loop never matched and the bridge channel was never hidden.
+            --
+            -- Channels come back as flat (name, zoneFlag) pairs, hence the stride of 2.
+            for i = 1, NUM_CHAT_WINDOWS do
+                local frame = _G[format('ChatFrame%d', i)]
+                if frame then
+                    local channels = { GetChatWindowChannels(i) }
+                    for j = 1, #channels, 2 do
+                        if channels[j] == self.name then
                             gw.Debug(GW_LOG_INFO, 'hiding channel: number=%d, name=%s, frame=%s',
-                                    self.number, gw.Redact(self.name), frame)
+                                    self.number, gw.Redact(self.name), frame:GetName())
+                            -- The FRAME, not its name. Since 1.15.9 ChatFrame_RemoveChannel is
+                            -- only a deprecation alias for ChatFrameMixin.RemoveChannel, which
+                            -- takes the frame as `self`; passing the name string indexes a
+                            -- string and raises.
                             ChatFrame_RemoveChannel(frame, self.name)
                         end
                     end

--- a/Config.lua
+++ b/Config.lua
@@ -213,9 +213,16 @@ function GwConfig:load()
                     end
                 elseif field[1] == 'v' then
                     -- Minimum version
-                    if strmatch(field[2], '^%d+%.%d+%.%d+%w*$') then
-                        self.minimum = tostring(semver(field[2]));
+                    -- Validate by PARSING rather than by regex: '^%d+%.%d+%.%d+%w*$' accepted
+                    -- forms semver() rejects (it wants a '-' before a pre-release, so '1.2.3beta'
+                    -- passed the regex and parsed to nothing), and tostring() with no argument
+                    -- then raised -- aborting the whole configuration parse over one mistyped line.
+                    local version = semver(tostring(field[2] or ''))
+                    if version then
+                        self.minimum = tostring(version);
                         gw.Debug(GW_LOG_DEBUG, 'minimum version set to %s', self.minimum);
+                    else
+                        gw.Debug(GW_LOG_ERROR, "invalid minimum version, '%s'", tostring(field[2]));
                     end
                 elseif field[1] == 'o' then
                     -- Deprecated option list
@@ -225,9 +232,13 @@ function GwConfig:load()
                         key = strlower(key)
                         val = strlower(val)
                         if key == 'mv' then
-                            if strmatch(val, '^%d+%.%d+%.%d+%w*$') then
-                                self.minimum = tostring(semver(val));
+                            -- Same parse-don't-regex treatment as the v directive above.
+                            local version = semver(tostring(val or ''))
+                            if version then
+                                self.minimum = tostring(version);
                                 gw.Debug(GW_LOG_DEBUG, 'minimum version set to %s', self.minimum);
+                            else
+                                gw.Debug(GW_LOG_ERROR, "invalid minimum version, '%s'", tostring(val));
                             end
                         end
                     end
@@ -289,7 +300,14 @@ end
 -- @return True is refresh submitted, false otherwise.
 function GwConfig:reload()
     self.valid = false
-    C_GuildInfo.GuildRoster()
+    -- Feature-detect rather than calling bare.  The tests in tests/TestConfig.lua assert this
+    -- fallback, so without the guard the suite is red; and a client without C_GuildInfo raises
+    -- here on the very first configuration load, which is before the bridge ever comes up.
+    if C_GuildInfo and C_GuildInfo.GuildRoster then
+        C_GuildInfo.GuildRoster()
+    else
+        GuildRoster()
+    end
     gw.Debug(GW_LOG_INFO, 'roster update requested.')
     return true
 end
@@ -353,8 +371,10 @@ end
 -- @param guild The name of the guild to check.
 -- @return True if the target guild is in the confederation, false otherwise.
 function GwConfig:is_container(guild)
-    if guild == self:GetGuildName() then
-        return self.guild_id ~= nil
+    -- gw.GetGuildName(), not self:GetGuildName() -- GwConfig has no such method, so every call
+    -- raised "attempt to call method 'GetGuildName' (a nil value)" on the first line.
+    if guild == gw.GetGuildName() then
+        return self.guild_id ~= nil and self.guild_id ~= ''
     else
         return self:is_peer(guild)
     end

--- a/Globals.lua
+++ b/Globals.lua
@@ -42,14 +42,20 @@ gw.usage = [[
         -- Print connection status.
   reload
         -- Reload the configuration.
+  refresh
+        -- Reload the configuration. Alias for reload.
   reset
         -- Reset communications and reload the configuration.
+  mode <account|character>
+        -- Share settings across all characters on the account, or keep them per-character.
   roster <on|off>
         -- Toggle display of confederation online, offline, join, and leave messages.
   tag <on|off>
         -- Show co-guild identifier in messages.
   ochat <on|off>
         -- Enable officer chat bridging.
+  joindelay <seconds>
+        -- Seconds to wait for the default channels before joining the bridge channel.
   dump
         -- Print configuration and state information.
   debug <level>

--- a/HoldDown.lua
+++ b/HoldDown.lua
@@ -58,7 +58,17 @@ function GwHoldDown:start(f)
     self.timestamp = t
     self.scale = 0
 
-    local frame = CreateFrame('frame')
+    -- Keep the timer frame ON THE INSTANCE, and reuse it.
+    --
+    -- Two problems with a bare local here. It was the only reference to the frame, so once start()
+    -- returned nothing held it and the timer could stop ticking without a trace -- the callback
+    -- simply never ran and no error was raised. And a fresh frame per start() is a leak: the
+    -- client never reclaims a CreateFrame frame, and refresh_channels restarts these timers for
+    -- the whole session.
+    if not self.frame then
+        self.frame = CreateFrame('frame')
+    end
+    local frame = self.frame
     frame:SetScript('OnUpdate', handler)
 
     gw.Debug(GW_LOG_NOTICE, 'hold-down start; timer=%s, timestamp=%d, expiry=%d, function=%s',

--- a/Lib/SemanticVersion.lua
+++ b/Lib/SemanticVersion.lua
@@ -3,7 +3,12 @@
 ----------------------------------------------------------------------------
 
 local VERSION_MAJOR = "SemanticVersion-1.0"
-local VERSION_MINOR = 1
+-- MINOR 2: pre-release precedence fixes (build metadata without a pre-release; antisymmetric
+-- identifier comparison; larger field sets ranking higher).  The bump is load-bearing, not
+-- bookkeeping -- LibStub:NewLibrary returns nil when `oldminor >= minor`, so at minor 1 this
+-- fixed copy would silently lose to any other addon's unfixed copy that happened to load first,
+-- and the defects would persist with nothing to show for the fix.
+local VERSION_MINOR = 2
 local SemVer = LibStub:NewLibrary(VERSION_MAJOR, VERSION_MINOR)
 if not SemVer then
     return
@@ -52,14 +57,20 @@ function SemVer.new(s)
     self.meta = {}
     
     if suffix and suffix ~= '' then
-        local valid, pre, meta = suffix:match('^(-([%w%.]+)%+?([%w%.]*))$')
-        if valid then
-            self.pre = split(pre)
-            self.meta = split(meta)
-            if not (self.pre and self.meta) then
+        local pre, meta = suffix:match('^-([%w%.]+)%+?([%w%.]*)$')
+        if not pre then
+            -- Build metadata may follow the patch directly, with no pre-release at all --
+            -- '1.0.0+20130313144700' is a valid version (semver 2.0.0 section 10).  Requiring a
+            -- leading '-' rejected the whole version string in that case.
+            meta = suffix:match('^%+([%w%.]+)$')
+            if not meta then
                 return
             end
-        else
+            pre = ''
+        end
+        self.pre = split(pre)
+        self.meta = split(meta)
+        if not (self.pre and self.meta) then
             return
         end
     end
@@ -92,13 +103,19 @@ local function cmp_version(lhs, rhs)
         if not lhs and not rhs then
             return 0
         elseif not lhs then
-            return 1
-        elseif not rhs then
+            -- Ran out of pre-release fields on the left.  "A larger set of pre-release fields has
+            -- a higher precedence than a smaller set" (semver 2.0.0 section 11), so the shorter
+            -- side ranks LOWER.  Returning 1 here made 1.0.0-alpha outrank 1.0.0-alpha.1.
             return -1
+        elseif not rhs then
+            return 1
         elseif type(lhs) == 'number' and type(rhs) == 'string' then
+            -- "Numeric identifiers always have lower precedence than non-numeric identifiers."
             return -1
         elseif type(lhs) == 'string' and type(rhs) == 'number' then
-            return -1
+            -- Returning -1 here too made the comparison non-antisymmetric: both a < b and b < a
+            -- were true, so any ordering built on it depended on argument order.
+            return 1
         else
             return lhs == rhs and 0 or lhs < rhs and -1 or 1
         end    

--- a/README.md
+++ b/README.md
@@ -215,10 +215,6 @@ To view the current configuration, you would enter one of the following.
 
   Print a summary of available commands. 
 
-- stats
-
-  Prints a summary of the connection statistics for the common communication channel(s). 
-
 - status
   
   Prints a summary of the GreenWall communication parameters and state variables. 

--- a/Settings.lua
+++ b/Settings.lua
@@ -151,13 +151,20 @@ end
 -- @param svtable Settings table reference
 -- @param meta True if meta options should be reset, false otherwise.
 function GwSettings:reset(svtable, meta)
+    -- GreenWallInterfaceFrame_SetDefaults calls this with no arguments, so a required svtable
+    -- made the Defaults button raise on the first key it looked at.
+    if svtable == nil then
+        svtable = self._data[self:mode()]
+    end
     for k, v in pairs(self._default) do
         if not v.meta or meta then
-            if svtable[k] == nil or self:validate(k, svtable[k]) then
-                svtable[k] = v.value
-            end
+            -- Unconditionally.  The "only if absent or invalid" guard belongs to initialize(),
+            -- which fills gaps; here the whole point is to overwrite values that are present and
+            -- valid, so carrying that guard over made reset() a no-op on any real store.
+            svtable[k] = v.value
         end
     end
+    svtable.updated = date('%Y-%m-%d %H:%M:%S')
 end
 
 

--- a/tests/TestAPI.lua
+++ b/tests/TestAPI.lua
@@ -112,6 +112,37 @@ end
 
 
 --
+-- A handler registered with '*' must receive messages from every addon.  The dispatcher tested
+-- whether the SENDER was named '*', which the registration asserts make impossible.
+--
+
+TestAPIWildcard = {}
+
+function TestAPIWildcard:setUp()
+    gw.api_table = {}
+    C_AddOns.GetAddOnInfo = function(addon) return addon end
+    gw.player = 'Ralff'
+    gw.config = { guild_id = 'G1' }
+end
+
+function TestAPIWildcard:test_wildcard_handler_receives_every_addon()
+    local hits = 0
+    GreenWallAPI.AddMessageHandler(function() hits = hits + 1 end, '*', 0)
+    gw.APIDispatcher('AddonA', 'Someone', 'G2', 'one')
+    gw.APIDispatcher('AddonB', 'Someone', 'G2', 'two')
+    lu.assertEquals(hits, 2)
+end
+
+function TestAPIWildcard:test_named_handler_is_still_selective()
+    local a, b = 0, 0
+    GreenWallAPI.AddMessageHandler(function() a = a + 1 end, 'AddonA', 0)
+    GreenWallAPI.AddMessageHandler(function() b = b + 1 end, 'AddonB', 0)
+    gw.APIDispatcher('AddonA', 'Someone', 'G2', 'hello')
+    lu.assertEquals(a, 1)
+    lu.assertEquals(b, 0)
+end
+
+--
 -- Run the tests
 --
 

--- a/tests/TestConfig.lua
+++ b/tests/TestConfig.lua
@@ -185,6 +185,100 @@ end
 
 
 --
+-- GwConfig:is_container() called self:GetGuildName(), which GwConfig does not define, so every
+-- call raised.  And a version the regex accepted but semver() rejects aborted the whole parse.
+--
+
+TestConfigContainer = {}
+
+function TestConfigContainer:setUp()
+    self.saved = { GetGuildName = gw.GetGuildName }
+    gw.GetGuildName = function() return 'TestGuild' end
+end
+
+function TestConfigContainer:tearDown()
+    gw.GetGuildName = self.saved.GetGuildName
+end
+
+function TestConfigContainer:test_own_guild_is_in_the_confederation()
+    local config = GwConfig.initialize_param({})
+    config.guild_id = 'TG'
+    config.is_peer = GwConfig.is_peer
+    config.is_container = GwConfig.is_container
+    lu.assertTrue(config:is_container('TestGuild'))
+end
+
+function TestConfigContainer:test_peer_is_in_the_confederation()
+    local config = GwConfig.initialize_param({})
+    config.guild_id = 'TG'
+    config.peer = { DA = 'Dead Air' }
+    config.is_peer = GwConfig.is_peer
+    config.is_container = GwConfig.is_container
+    lu.assertTrue(config:is_container('Dead Air'))
+    lu.assertFalse(config:is_container('Some Randoms'))
+end
+
+function TestConfigContainer:test_own_guild_without_a_tag_is_not_configured()
+    local config = GwConfig.initialize_param({})
+    config.is_peer = GwConfig.is_peer
+    config.is_container = GwConfig.is_container
+    lu.assertFalse(config:is_container('TestGuild'))
+end
+
+
+TestConfigVersionDirective = {}
+
+function TestConfigVersionDirective:setUp()
+    self.saved = {
+        GetGuildInfoText = GetGuildInfoText,
+        GetGuildName = gw.GetGuildName,
+        version = gw.version,
+        settings = gw.settings,
+        time = time,
+    }
+    gw.settings = GwSettings:new()
+    -- Above any minimum these cases configure, so load() does not take the version-warning path
+    -- (gw.Error needs a DEFAULT_CHAT_FRAME that the mock does not provide).
+    gw.version = '9.9.9'
+    gw.GetGuildName = function() return 'TestGuild' end
+    time = os.time
+end
+
+function TestConfigVersionDirective:tearDown()
+    GetGuildInfoText = self.saved.GetGuildInfoText
+    gw.GetGuildName = self.saved.GetGuildName
+    gw.version = self.saved.version
+    gw.settings = self.saved.settings
+    time = self.saved.time
+end
+
+local function info(...)
+    return table.concat({ ... }, '\n') .. '\n'
+end
+
+function TestConfigVersionDirective:test_valid_minimum_version_is_recorded()
+    GetGuildInfoText = function()
+        return info('GW:c:Chan:pass', 'GW:v:1.2.3')
+    end
+    local config = GwConfig:new()
+    lu.assertTrue(config:load())
+    lu.assertEquals(config.minimum, '1.2.3')
+end
+
+function TestConfigVersionDirective:test_unparseable_version_does_not_abort_the_parse()
+    -- '1.2.3beta' passes a '^%d+%.%d+%.%d+%w*$' regex but semver() rejects it, and tostring()
+    -- with no argument then raised -- taking down the whole configuration over one mistyped line.
+    -- The directives after the bad line must still be read.
+    GetGuildInfoText = function()
+        return info('GW:c:Chan:pass', 'GW:v:1.2.3beta', 'GW:p:Dead Air:DA')
+    end
+    local config = GwConfig:new()
+    lu.assertTrue(config:load())
+    lu.assertEquals(config.minimum, '')
+    lu.assertEquals(config.peer['DA'], gw.GlobalName('Dead Air'))
+end
+
+--
 -- Run the tests
 --
 

--- a/tests/TestHoldDown.lua
+++ b/tests/TestHoldDown.lua
@@ -155,6 +155,29 @@ end
 
 
 --
+-- GwHoldDown:start must keep the frame it creates.  A bare local went out of scope the moment
+-- start() returned, so nothing referenced the frame driving the timer.
+--
+
+TestHoldDownFrame = {}
+
+function TestHoldDownFrame:test_frame_is_retained()
+    local h = GwHoldDown:new(10)
+    h:start()
+    lu.assertNotNil(h.frame)
+end
+
+function TestHoldDownFrame:test_frame_is_reused_across_starts()
+    -- refresh_channels restarts these timers for the whole session; a fresh frame per start is a
+    -- leak, because the client never reclaims a CreateFrame frame.
+    local h = GwHoldDown:new(10)
+    h:start()
+    local first = h.frame
+    h:start()
+    lu.assertIs(h.frame, first)
+end
+
+--
 -- Run the tests
 --
 

--- a/tests/TestSemanticVersion.lua
+++ b/tests/TestSemanticVersion.lua
@@ -1,0 +1,160 @@
+--[[--------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2010-2020 Mark Rogaski
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--]]--------------------------------------------------------------------------
+
+---@diagnostic disable: undefined-global
+
+lu = require('luaunit')
+require('Loader')
+
+local semver = LibStub:GetLibrary('SemanticVersion-1.0')
+
+local function v(s)
+    return semver(s)
+end
+
+
+--
+-- Parsing.
+--
+
+TestSemanticVersionParse = {}
+
+function TestSemanticVersionParse:test_plain_version()
+    local ver = v('1.2.3')
+    lu.assertEquals(ver.major, 1)
+    lu.assertEquals(ver.minor, 2)
+    lu.assertEquals(ver.patch, 3)
+    lu.assertEquals(ver.pre, {})
+    lu.assertEquals(ver.meta, {})
+end
+
+function TestSemanticVersionParse:test_prerelease()
+    lu.assertEquals(v('1.0.0-alpha.1').pre, { 'alpha', 1 })
+end
+
+function TestSemanticVersionParse:test_rejects_malformed()
+    lu.assertNil(v('not.a.version'))
+    lu.assertNil(v('1.2'))
+    lu.assertNil(v(''))
+end
+
+function TestSemanticVersionParse:test_rejects_suffix_without_separator()
+    -- A pre-release needs the '-'.  GwConfig's GW:v: handler relies on this rejection.
+    lu.assertNil(v('1.2.3beta'))
+end
+
+function TestSemanticVersionParse:test_rejects_leading_zero_identifier()
+    -- semver.org 2.0.0 section 9: numeric identifiers must not include leading zeroes.
+    lu.assertNil(v('1.0.0-01'))
+end
+
+function TestSemanticVersionParse:test_metadata_with_prerelease()
+    local ver = v('1.0.0-alpha+build.1')
+    lu.assertEquals(ver.pre, { 'alpha' })
+    lu.assertEquals(ver.meta, { 'build', 1 })
+end
+
+function TestSemanticVersionParse:test_metadata_without_prerelease()
+    -- semver.org 2.0.0 section 10: build metadata may follow the patch directly.  Requiring a
+    -- leading '-' rejected the whole version string.
+    local ver = v('1.0.0+20130313144700')
+    lu.assertNotNil(ver)
+    lu.assertEquals(ver.pre, {})
+    lu.assertEquals(ver.meta, { 20130313144700 })
+end
+
+
+--
+-- Rendering.
+--
+
+TestSemanticVersionString = {}
+
+function TestSemanticVersionString:test_round_trip()
+    lu.assertEquals(tostring(v('1.2.3')), '1.2.3')
+    lu.assertEquals(tostring(v('1.0.0-alpha.1')), '1.0.0-alpha.1')
+    lu.assertEquals(tostring(v('1.0.0-alpha+build.1')), '1.0.0-alpha+build.1')
+end
+
+
+--
+-- Precedence.  semver.org 2.0.0 section 11.
+--
+
+TestSemanticVersionPrecedence = {}
+
+function TestSemanticVersionPrecedence:test_major_minor_patch()
+    lu.assertTrue(v('1.0.0') < v('2.0.0'))
+    lu.assertTrue(v('2.0.0') < v('2.1.0'))
+    lu.assertTrue(v('2.1.0') < v('2.1.1'))
+end
+
+function TestSemanticVersionPrecedence:test_equality()
+    lu.assertTrue(v('1.2.3') == v('1.2.3'))
+    lu.assertTrue(v('1.2.3') <= v('1.2.3'))
+end
+
+function TestSemanticVersionPrecedence:test_prerelease_below_release()
+    lu.assertTrue(v('1.0.0-alpha') < v('1.0.0'))
+    lu.assertFalse(v('1.0.0') < v('1.0.0-alpha'))
+end
+
+function TestSemanticVersionPrecedence:test_numeric_below_alphanumeric()
+    -- "Numeric identifiers always have lower precedence than non-numeric identifiers."
+    lu.assertTrue(v('1.0.0-1') < v('1.0.0-alpha'))
+end
+
+function TestSemanticVersionPrecedence:test_antisymmetric_across_types()
+    -- If a < b then b < a must be false.  Both being true makes any ordering built on this
+    -- comparison depend on the argument order.
+    lu.assertFalse(v('1.0.0-alpha') < v('1.0.0-1'))
+end
+
+function TestSemanticVersionPrecedence:test_smaller_field_set_ranks_lower()
+    -- "A larger set of pre-release fields has a higher precedence than a smaller set, if all of
+    -- the preceding identifiers are equal."
+    lu.assertTrue(v('1.0.0-alpha') < v('1.0.0-alpha.1'))
+end
+
+function TestSemanticVersionPrecedence:test_antisymmetric_across_field_counts()
+    lu.assertFalse(v('1.0.0-alpha.1') < v('1.0.0-alpha'))
+    lu.assertTrue(v('1.0.0-alpha') <= v('1.0.0-alpha.1'))
+end
+
+function TestSemanticVersionPrecedence:test_specification_example()
+    local order = { '1.0.0-alpha', '1.0.0-alpha.1', '1.0.0-alpha.beta', '1.0.0-beta',
+                    '1.0.0-beta.2', '1.0.0-beta.11', '1.0.0-rc.1', '1.0.0' }
+    for i = 1, #order - 1 do
+        lu.assertTrue(v(order[i]) < v(order[i + 1]),
+                string.format('%s should rank below %s', order[i], order[i + 1]))
+    end
+end
+
+function TestSemanticVersionPrecedence:test_metadata_ignored()
+    -- semver.org 2.0.0 section 10: build metadata must be ignored when determining precedence.
+    lu.assertTrue(v('1.0.0+build.1') == v('1.0.0+build.2'))
+end
+
+
+--
+-- Run the tests
+--
+
+os.exit(lu.run())

--- a/tests/TestSettings.lua
+++ b/tests/TestSettings.lua
@@ -232,6 +232,43 @@ end
 
 
 --
+-- GwSettings:reset() is called by the Interface Options "Defaults" button with NO arguments, and
+-- its body only assigned a default when the stored value was absent or invalid -- a guard that
+-- belongs to initialize(), making reset() a no-op on any real store.
+--
+
+TestSettingsReset = {}
+
+function TestSettingsReset:setUp()
+    GreenWallMeta = nil
+    GreenWall = nil
+    GreenWallAccount = nil
+end
+
+function TestSettingsReset:test_overwrites_values_that_are_present_and_valid()
+    local settings = GwSettings:new()
+    settings:set('tag', false)
+    settings:set('logsize', 512)
+    settings:reset(GreenWallAccount)
+    lu.assertEquals(GreenWallAccount.tag, true)
+    lu.assertEquals(GreenWallAccount.logsize, 2048)
+end
+
+function TestSettingsReset:test_defaults_to_the_active_store()
+    local settings = GwSettings:new()
+    settings:set('tag', false)
+    settings:reset()
+    lu.assertEquals(settings:get('tag'), true)
+end
+
+function TestSettingsReset:test_leaves_meta_settings_alone()
+    local settings = GwSettings:new()
+    GreenWallMeta.mode = GW_MODE_CHARACTER
+    settings:reset()
+    lu.assertEquals(GreenWallMeta.mode, GW_MODE_CHARACTER)
+end
+
+--
 -- Run the tests
 --
 


### PR DESCRIPTION
Eight defects, each found by running the existing `tests/` suite offline and writing a test for
what the code *should* do. Every fix has a regression test in this PR.

**The suite on this branch is currently red** — two errors in `TestConfig`. `GwConfig:reload()`
calls `C_GuildInfo.GuildRoster()` bare, while `tests/TestConfig.lua` asserts a fallback to the
global. The first commit restores the feature-detect so the two agree; it also protects a client
without the namespace, which raises there on the very first configuration load, before the bridge
comes up.

### The rest

- **`GW:v:` could abort the entire configuration parse.** The guard
  `'^%d+%.%d+%.%d+%w*$'` accepts `1.2.3beta`, which is not a semantic version — a pre-release needs
  the `-`. `semver()` returns nothing, `tostring()` then raises with no argument, and `load()`
  unwinds before the channel, peer and officer directives on the following lines are read. One
  mistyped character in the Guild Information panel takes a whole confederation's configuration
  down. Now validated by parsing rather than by regex.
- **`GwConfig:is_container()` raised on every call** — `self:GetGuildName()`, which `GwConfig` does
  not define. The helper is `gw.GetGuildName()`.
- **The Interface Options "Defaults" button raised.** `GwSettings:reset()` requires an `svtable`,
  but `GreenWallInterfaceFrame_SetDefaults` calls it with none. Underneath sat a second defect:
  the body only assigned a default when the stored value was *absent or invalid* — a guard that
  belongs to `initialize()`, making `reset()` a no-op on any real store even when called correctly.
- **API handlers registered with `'*'` never received anything.** The dispatcher tested whether the
  *sending* addon was named `'*'`, but `AddMessageHandler` and `SendMessage` both assert the addon
  against `C_AddOns.GetAddOnInfo`, so no real sender can be. The wildcard belongs to the
  registration, as `API.md` documents.
- **The bridge channel was never hidden.** `GwChannel:join()` scans `GetChatWindowMessages()` for
  the channel name, but that returns message *group* names (`GUILD`, `SAY`) — the channel list is
  `GetChatWindowChannels()`. Blizzard reads the two into `RegisterForMessages` and
  `RegisterForChannels` respectively, so a group name can never equal a channel name and the loop
  matches nothing. Had it matched it would have raised: `ChatFrame_RemoveChannel` is a deprecation
  alias for `ChatFrameMixin.RemoveChannel`, which takes the frame as `self`, and the call passed the
  frame's **name**.
- **Hold-down timers could stop firing silently, and leaked a frame per start.** `GwHoldDown:start()`
  created its `OnUpdate` frame into a bare local; nothing else referenced it, because the handler
  takes `frame` as a parameter rather than capturing it. A timer that stops produces no error at
  all. Created once, kept on the instance, reused.
- **Three pre-release precedence defects in `Lib/SemanticVersion.lua`**, in code that had never
  executed: a version with build metadata but no pre-release (`1.0.0+20130313144700`, valid per
  semver 2.0.0 §10) was rejected outright; the comparison was not antisymmetric, so
  `1.0.0-alpha < 1.0.0-1` and `1.0.0-1 < 1.0.0-alpha` were both true; and a shorter pre-release
  outranked a longer one, making `1.0.0-alpha` rank above `1.0.0-alpha.1`. `TestSemanticVersion.lua`
  walks the specification's own worked example.

  **`VERSION_MINOR` goes 1 → 2**, which is load-bearing rather than bookkeeping:
  `LibStub:NewLibrary` returns nil when `oldminor >= minor`, so at an unchanged minor this corrected
  copy would lose to any other add-on carrying an older copy that loaded first, and the fixes would
  ship without ever running.

### Docs

`gw.usage` did not list `mode`, `joindelay` or `refresh`, so three working commands were
undiscoverable in game. `README.md` documented a `stats` command that has never existed — the slash
handler has no such branch.

### Testing

All seven test files pass on this branch. luaunit is not vendored here, so:

```sh
LUA_PATH="./?.lua;./tests/?.lua;/path/to/luaunit/?.lua;;" lua tests/TestSemanticVersion.lua
```

The `SemanticVersion` tests fail 5/17 against the unfixed library and pass 17/17 with the fix.

Same change is offered against `main`, `release/classic` and `release/classic-era`.
